### PR TITLE
(do not merge) Fix ERR_PACKAGE_PATH_NOT_EXPORTED by removing app/not-found.jsx

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -1,3 +1,0 @@
-export default async function NotFound() {
-  return "Not Found";
-}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Page</div>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "next.js-repro-repo",
   "version": "1.3.39",
   "lockfileVersion": 2,
   "requires": true,


### PR DESCRIPTION
Fixes the following exception by removing the `app/not-found.jsx` file

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './server.edge' is not defined by "exports" in /Users/christian/code/next.js-repro-repo/.next/standalone/node_modules/react-dom/package.json
    at new NodeError (node:internal/errors:399:5)
    at exportsNotFound (node:internal/modules/esm/resolve:361:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:697:9)
    at resolveExports (node:internal/modules/cjs/loader:565:36)
    at Module._findPath (node:internal/modules/cjs/loader:634:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1061:27)
    at /Users/christian/code/next.js-repro-repo/.next/standalone/node_modules/next/dist/server/require-hook.js:196:36
    at Module._load (node:internal/modules/cjs/loader:920:27)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```

More context in https://github.com/vercel/next.js/issues/50232